### PR TITLE
Fix split error caused by gff disorder

### DIFF
--- a/lib/Bio/WGS2NCBI.pm
+++ b/lib/Bio/WGS2NCBI.pm
@@ -155,7 +155,7 @@ sub prepare {
 				close $handles{$fifo};
 				delete $handles{$fifo};
 			}
-			open $handles{$chr}, '>', "${gff3dir}/${chr}.gff3" or die $!;
+			open $handles{$chr}, '>>', "${gff3dir}/${chr}.gff3" or die $!;
 			push @queue, $chr;
 		}
 		my $fh = $handles{$chr};


### PR DESCRIPTION
If the `.gff` is not sorted, reopening the file handle will overwrite the previous record
such as:

```
Contig00001     EVM     gene    100 2000 .       -       .       ID=xxxxx;Name=xxxxx.1
Contig00002 ...
Contig00003 ...
... #100 other contigs
Contig00001     EVM     gene    3000 4000 .       -       .       ID=xxxxx;Name=xxxxx.1
```

We can only get the last record